### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ These instructions are for debian-based versions of GNU/Linux. It is recommended
 
 Required Packages
 -----------------
-    sudo apt-get install python3 python3-setuptools git 
+    sudo apt-get install python3 python3-pip python3-setuptools git 
 
 VirtualEnvWrapper
 -----------------


### PR DESCRIPTION
The current version of this README doesn't include any mention of installing the appropriate package for pip3. I just tried to install this project on Ubuntu 16.04LTS and python3/python3-setuptools doesn't include pip3. I'm not sure if Debian automatically includes pip3 with the installation of python3 or not...but if it does, maybe instead of adding in ```python3-pip``` to the "Required Packages" section, you could add a note that some Debian systems may not include pip3 in the Python3 installation, and note that pip3 might need to be installed as it's own package.