### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,10 @@ Add the following to your shell init script. e.g. ~/.bashrc or ~/.zshrc
     export VIRTUALENVWRAPPER_PYTHON=/usr/bin/python3
     export WORKON_HOME=~/virtualenvs
 
+[Initialize virtualwrapper](http://virtualenvwrapper.readthedocs.io/en/latest/index.html#introduction)
+
+    source /usr/local/bin/virtualenvwrapper.sh
+    
 Create a virtual environment for Orthosie.
 
     mkvirtualenv orthosie


### PR DESCRIPTION
In order to user the `mkvirtualenv` command, I needed to first initialize virtualwrapper. Again, I'm working off of Ubuntu 16.04LTS, so I'm not sure if Debian doesn't have this step.
